### PR TITLE
Webpack aliases starting point

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,12 @@ module.exports = {
     ]
   },
 
+  resolve: {
+    alias: {
+      components: path.resolve(__dirname, 'modules/client/components')
+    }
+  },
+  
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
Every new webpack project I end up at some point setting up a handful of aliases (usually `components`, `styles`, `containers` and utils widely used across the app).

I also find myself copy and pasting this chunk of code from previous projects since webpack config structure is kinda hard to remember and we're all lazy developers.

This in place makes it trivial for a developer to jump in and start adding her own aliases.
