### PR TITLE
Use contenthash for ExtractTextPlugin filename

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
       filename: 'chunk-manifest.json',
       manifestVariable: 'webpackManifest'
     }),
-    new ExtractTextPlugin('[chunkhash:8]-styles.css'),
+    new ExtractTextPlugin('[contenthash:8]-styles.css'),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
     }),


### PR DESCRIPTION
It's a warning sign if multiple files coming out of the same chunk have the same hash, as they'll always change together.

![sublime_text_2016-07-22_04-16-02](https://cloud.githubusercontent.com/assets/226692/17034128/a23a04b4-4fc4-11e6-80c5-ba0897842a1d.png)

Screenshot with this change in place, running 2 builds, only changing Home.js after the first one:

![sublime_text_2016-07-22_04-28-30](https://cloud.githubusercontent.com/assets/226692/17034159/c2ced89e-4fc4-11e6-9872-642869e3d652.png)
